### PR TITLE
Support accessory touch able control property

### DIFF
--- a/VTextView/Classes/VTextStorage.swift
+++ b/VTextView/Classes/VTextStorage.swift
@@ -205,7 +205,8 @@ extension VTextStorage {
     }
     
     internal func triggerTouchEventIfNeeds(_ textView: VTextView) {
-        guard self.isFlyToTargetLocationWithoutTyping(textView),
+        guard textView.isEnableTouchEvent,
+            self.isFlyToTargetLocationWithoutTyping(textView),
             textView.selectedRange.length < 1,
             let attrs = self.typingManager?
                 .accessoryDelegate

--- a/VTextView/Classes/VTextView.swift
+++ b/VTextView/Classes/VTextView.swift
@@ -17,6 +17,7 @@ open class VTextView: UITextView, UITextViewDelegate {
         }
     }
     
+    public var isEnableTouchEvent: Bool = false
     let disposeBag = DisposeBag()
     
     public required init(manager: VTextManager) {
@@ -27,7 +28,7 @@ open class VTextView: UITextView, UITextViewDelegate {
         textStorage.addLayoutManager(layoutManager)
         super.init(frame: .zero, textContainer: textContainer)
         super.delegate = self
-        self.autocorrectionType = .no
+        self.isEnableTouchEvent = !self.isEditable
         
         manager.currentAttributesRelay.observeOn(MainScheduler.instance)
             .subscribe(onNext: { [weak self] attr in


### PR DESCRIPTION
## Why need this change?: 
- Accessory Touch Event can block/unblock


## Change made & impact:
- Support accessory touch able control property from VTextView


## Test Scope:
- Coming soon

## Vertified snapshots (optional)
